### PR TITLE
Fix growbox time bug

### DIFF
--- a/growbox/arduino_thread.py
+++ b/growbox/arduino_thread.py
@@ -56,7 +56,7 @@ def read_arduino(db):
                 data = json.loads(sp.read_serial())
                 if not first_data_pack_flag:
                     reconnect_count = 0
-                    current_time = datetime.fromtimestamp(data["time"])
+                    current_time = datetime.utcfromtimestamp(data["time"])
                     systime_settings.set_systime(str(current_time))
                     first_data_pack_flag = True
             empty_loop_count += 1


### PR DESCRIPTION
1) Мы устанавливаем время в приложении на малине.
2) Это время летит в гроуборд в уарт например в формате  Fri Jan 21 15:22:00 2022 .
3) На гроуборде время переводится в UTC timestamp и заливается в RTC.
4) Гроуборд каждые 2 сек отсылвает на малину timestamp с RTC. Время в формате UTC.
5) Малина прошивает новое время в ститему каждые 2 секунды но не учитывает таймзон. Мы получаем время +3 часа 18:22:00. +3 так как мы устанавливаем MSK часовой пояс при настройке образа Raspbian.

